### PR TITLE
Promote op_run gist to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# op_run
+# `op_run` command
+
+`op_run` wrap `op run` at Linux or MacOS and `oprun` at WSL (Windows Subsystem for Linux).
+
+## Dependency
+
+- Linux or MacOS -> `op run` exists
+- WSL (WindowsOS) -> `oprun` ([pollenjp/oprun.sh](https://github.com/pollenjp/oprun.sh)) exists
+
+## Install script
+
+```bash
+op_run_path=~/.local/bin/op_run
+mkdir -p "${op_run_path%/*}"
+curl -fsSL https://raw.githubusercontent.com/pollenjp/op_run/main/op_run \
+  -o "${op_run_path:?}"
+chmod +x "${op_run_path:?}"
+```

--- a/op_run
+++ b/op_run
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -e | --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: Unknown option $1" >&2
+      exit 1
+      ;;
+    *)
+      # command part starts here
+      break
+      ;;
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "Error: No command specified" >&2
+  exit 1
+fi
+
+if [[ -z "${ENV_FILE:-}" ]]; then
+  echo "Error: No env file specified" >&2
+  exit 1
+fi
+
+op_run_cmd=()
+if uname -r | grep microsoft | grep WSL &>/dev/null; then
+  # if WSL
+  # ex) 6.6.87.2-microsoft-standard-WSL2
+  op_run_cmd+=(oprun -v -q)
+  if ! command -v oprun >/dev/null; then
+    echo "Install 'oprun' command from https://github.com/pollenjp/oprun.sh" >&2
+    exit 1
+  fi
+else # simple linux (not WSL)
+  op_run_cmd+=(op run)
+fi
+
+"${op_run_cmd[@]}" --env-file "${ENV_FILE:?}" -- "${@}"


### PR DESCRIPTION
## Summary

Promote the contents of gist [edcfeb3ce54988f9d5f7360ac07357c8](https://gist.github.com/pollenjp/edcfeb3ce54988f9d5f7360ac07357c8) into this repository.

- Add the `op_run` wrapper script (executable) that delegates to `op run` on Linux/macOS or `oprun` on WSL.
- Replace the placeholder `README.md` with the gist's documentation (formerly `00_README.md`).
- Update the install snippet to fetch the script from this repository's raw URL instead of the gist.

## Test plan

- [ ] `bash -n op_run` parses without syntax errors
- [ ] `./op_run` (no args) prints the "No command specified" error
- [ ] `./op_run --env-file .env -- echo hi` invokes the correct backend on Linux/macOS and WSL
- [ ] Install snippet in README downloads the script and produces an executable

https://claude.ai/code/session_01Y4xVefeLu94nAxDMEaR6Da

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4xVefeLu94nAxDMEaR6Da)_