### PR TITLE
ci: use release environment for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,25 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment:
+      name: release
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
+      # Generating a GitHub token, so that PRs and tags created by
+      # the release-please-action can trigger actions workflows.
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: generate-token
         with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Aligns op_run's release workflow with the pattern used in [setup-shfmt](https://github.com/pollenjp/setup-shfmt/blob/main/.github/workflows/release-please.yml):

- Runs the `release-please` job under the `release` GitHub environment.
- Generates a GitHub App token via `actions/create-github-app-token` using `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY` secrets, so PRs and tags created by release-please can trigger downstream workflows (unlike the default `GITHUB_TOKEN`).
- Pins `googleapis/release-please-action` to a SHA (v5.0.0).

## Test plan

- [ ] Configure the `release` environment in repo settings with `RELEASE_PLEASE_APP_ID` and `RELEASE_PLEASE_APP_PRIVATE_KEY` secrets.
- [ ] Merge to `main` and verify the release-please job runs and opens/updates a release PR using the app token.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sj2FPHZ5mdSntQdzJX2Wu5)_