### PR TITLE
docs: add mise installation instructions and clarify oprun.sh dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,48 @@
 - Linux or MacOS -> `op run` exists
 - WSL (WindowsOS) -> `oprun` ([pollenjp/oprun.sh](https://github.com/pollenjp/oprun.sh)) exists
 
-## Install script
+  On WSL, `op_run` calls `oprun` from [pollenjp/oprun.sh](https://github.com/pollenjp/oprun.sh)
+  under the hood, so you need to install it as well. The easiest way is via
+  [mise](https://mise.jdx.dev/):
+
+  ```bash
+  # Latest release
+  mise use -g github:pollenjp/oprun.sh
+
+  # Pinned version
+  mise use -g github:pollenjp/oprun.sh@v0.2.0
+  ```
+
+  Or in `mise.toml`:
+
+  ```toml
+  [tools]
+  "github:pollenjp/oprun.sh" = "latest"
+  ```
+
+## Installation
+
+### Option 1: mise (via the GitHub backend)
+
+If you use [mise](https://mise.jdx.dev/), you can install `op_run` from the
+[GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html):
+
+```bash
+# Latest release
+mise use -g github:pollenjp/op_run
+
+# Pinned version
+mise use -g github:pollenjp/op_run@v0.2.0
+```
+
+Or in `mise.toml`:
+
+```toml
+[tools]
+"github:pollenjp/op_run" = "latest"
+```
+
+### Option 2: Install script
 
 ```bash
 op_run_path=~/.local/bin/op_run


### PR DESCRIPTION
## Summary

- Add `mise use github:pollenjp/op_run` as a recommended installation option in the README, mirroring how [pollenjp/oprun.sh](https://github.com/pollenjp/oprun.sh) documents its mise install.
- Make the WSL dependency on `oprun` from `pollenjp/oprun.sh` explicit, and include `mise use github:pollenjp/oprun.sh` so users can install the dependency the same way.

## Test plan

- [ ] `mise use -g github:pollenjp/op_run` installs `op_run` and it is on `$PATH`
- [ ] On WSL, `mise use -g github:pollenjp/oprun.sh` followed by `op_run -e .env.template -- echo hello` works


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtUxYKu2Hr2YsPnjR6wkFJ)_