### PR TITLE
ci: use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: generate-token
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - name: Run release-please
         id: release


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token` の推奨入力が `app-id` から `client-id` に変更されたため、`release.yml` を更新しました。
- あわせてシークレット名を `RELEASE_PLEASE_APP_ID` → `RELEASE_PLEASE_APP_CLIENT_ID` にリネームしています。

## 注意 / TODO

- リポジトリの GitHub Environment (`release`) に **`RELEASE_PLEASE_APP_CLIENT_ID`** シークレットを追加する必要があります。値は GitHub App の **Client ID** (`Iv23li...` 形式) で、App ID (数値) ではない点に注意してください。
- 旧シークレット `RELEASE_PLEASE_APP_ID` はマージ後に削除して構いません。

## Test plan

- [ ] `release` Environment に `RELEASE_PLEASE_APP_CLIENT_ID` を設定する
- [ ] マージ後、release-please ワークフローが正常にトークンを生成できることを確認する


---
_Generated by [Claude Code](https://claude.ai/code/session_01RB7WdcvV2dtkb4BaL4qAuw)_